### PR TITLE
Don't report swap metrics if swap is disabled

### DIFF
--- a/bin/instrument_server
+++ b/bin/instrument_server
@@ -228,6 +228,7 @@ class SystemInspector
 
     def self.swap
       _, total, used, free = `free -k -o | grep Swap`.chomp.split(/\s+/)
+      return {} if total.to_i == 0
       {
         'swap.used_mb' => used.to_f / 1024,
         'swap.free_mb' => free.to_f / 1024,


### PR DESCRIPTION
If swap is disabled then instrumental_tools reports agent.invalid_value. This change ignores swap if it is disabled, which is the default behavior on AWS EC2 images.
