### PR TITLE
Handle nonexistent device file path

### DIFF
--- a/lib/instrumental_tools/system_inspector/linux.rb
+++ b/lib/instrumental_tools/system_inspector/linux.rb
@@ -143,7 +143,7 @@ class SystemInspector
     def self.disk_io
       output          = {}
       device_root     = "/dev/"
-      mounted_devices = File.read(mount_file).lines.map { |l| l.split.first }.select { |device| device.index(device_root) }.map { |device| File.realpath(device) }
+      mounted_devices = File.read(mount_file).lines.map { |l| l.split.first }.select { |device| device.index(device_root) }.map { |device| File.exists?(device) ? File.realpath(device) : nil }.compact
       diskstats_lines = File.read(disk_file).lines.map(&:split).select { |values| mounted_devices.include?(File.join(device_root, values[2])) }
       entries         = diskstats_lines.map do |values|
                           entry               = {}


### PR DESCRIPTION
In some cases, `/proc/mounts` may refer to a device file that is not visible in the host system. This is notably occurring in a customer's Docker container ( node:0.12.4  ) ; this handles the case where the file is not present by omitting attempting to fetch disk stats for that mounted dir. In such cases, we defer responsibility for collecting disk stats to the container host, which may also run instrument_server if necessary.

